### PR TITLE
Manually ack-ing messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,63 @@ Tackle.consume(options) do |message|
 end
 ```
 
+## Manually ack-ing messages
+
+By default, Tackle assumes that a message was successfully processed if no
+exceptions were raised in the consume block. This behaviour is well suited for
+handling unknown exceptions.
+
+Sometimes however, we want to send a message to the retry queue without raising
+an exception (and polluting our exception tracker with false positives).
+
+For this purpose, tackle can be configured to consume messages in a "manual ack"
+fashion. Pass `:manual_ack => true` to the consumer to activate the manual_ack
+mode.
+
+```ruby
+require "tackle"
+
+options = {
+  :url => "amqp://localhost",
+  :exchange => "users",
+  :routing_key => "signed-up",
+  :service => "user-mailer"
+  :manual_ack => true
+}
+
+Tackle.consume(options) do |message|
+  puts message
+
+  Tackle::ACK
+end
+```
+
+When Tackle consumes messages in the manual_ack mode, the return value of the
+consumer block must be either `Tackle::ACK` or `Tackle::NACK`. In case the
+response is `Tackle::NACK` the message is put on the retry queue.
+
+```ruby
+require "tackle"
+
+options = {
+  :url => "amqp://localhost",
+  :exchange => "numbers",
+  :routing_key => "positive-numbers",
+  :service => "number-processor",
+  :manual_ack => true
+}
+
+Tackle.consume(options) do |message|
+  # accept only positive numbers
+
+  if message["value"].even?
+    Tackle::ACK
+  else
+    Tackle::NACK
+  end
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then,

--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ Tackle.consume(options) do |message|
 end
 ```
 
+If neither Tackle::ACK nor Tackle::NACK are returned, tackle assumes
+that the response is negative.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then,

--- a/lib/tackle.rb
+++ b/lib/tackle.rb
@@ -7,6 +7,9 @@ module Tackle
   require "tackle/publisher"
   require "tackle/consumer"
 
+  ACK = :ack
+  NACK = :nack
+
   module_function
 
   def consume(params = {}, &block)

--- a/lib/tackle/consumer/params.rb
+++ b/lib/tackle/consumer/params.rb
@@ -10,6 +10,7 @@ module Tackle
       attr_reader :retry_delay
       attr_reader :logger
       attr_reader :exception_handler
+      attr_reader :manual_ack
 
       def initialize(params = {})
         # required
@@ -22,8 +23,13 @@ module Tackle
         @retry_limit = params[:retry_limit] || 8
         @retry_delay = params[:retry_delay] || 30
         @logger      = params[:logger] || Logger.new(STDOUT)
+        @manual_ack  = params.fetch(:manual_ack, false)
 
         @exception_handler = params[:exception_handler]
+      end
+
+      def manual_ack?
+        @manual_ack == true
       end
 
     end

--- a/lib/tackle/version.rb
+++ b/lib/tackle/version.rb
@@ -1,3 +1,3 @@
 module Tackle
-  VERSION = "1.0"
+  VERSION = "1.1.0".freeze
 end

--- a/spec/integration/manual_ack_spec.rb
+++ b/spec/integration/manual_ack_spec.rb
@@ -1,0 +1,56 @@
+require "spec_helper"
+
+describe "Manual Ack Mode" do
+  before(:all) do
+    @messages = []
+
+    @tackle_options = {
+      :url => "amqp://localhost",
+      :exchange => "test-exchange",
+      :routing_key => "test-key",
+      :service => "manual-acking-service",
+      :retry_delay => 1,
+      :retry_limit => 3,
+      :manual_ack => true
+    }
+
+    @acking_worker = Thread.new do
+      Tackle.consume(@tackle_options) do |message|
+        # accept only positive numbers
+        @messages << message
+
+        if message["value"].to_i.even?
+          Tackle::ACK
+        else
+          Tackle::NACK
+        end
+      end
+    end
+
+    sleep 2
+  end
+
+  after(:all) do
+    @worker.kill
+  end
+
+  describe "acked messages" do
+    before do
+      Tackle.publish("2", @tackle_options) # will be processed
+
+      sleep 5
+    end
+
+    it "processes the message only once" do
+      expect(@messages).to eq([2])
+    end
+
+    it "cleares the queue" do
+      expect(BunnyHelper.message_count("manual-acking-service.test-key")).to be(0)
+    end
+
+    it "leaves the dead queue empty" do
+      expect(BunnyHelper.message_count("manual-acking-service.test-key.dead")).to be(0)
+    end
+  end
+end

--- a/spec/integration/manual_ack_spec.rb
+++ b/spec/integration/manual_ack_spec.rb
@@ -4,6 +4,9 @@ describe "Manual Ack Mode" do
   before(:all) do
     @messages = []
 
+    BunnyHelper.delete_queue("manual-acking-service.test-key")
+    BunnyHelper.delete_queue("manual-acking-service.test-key.dead")
+
     @tackle_options = {
       :url => "amqp://localhost",
       :exchange => "test-exchange",
@@ -20,7 +23,7 @@ describe "Manual Ack Mode" do
 
         @messages << message
 
-        if message["value"].to_i.even?
+        if message.to_i.even?
           Tackle::ACK
         else
           Tackle::NACK
@@ -37,7 +40,7 @@ describe "Manual Ack Mode" do
 
   describe "acked messages" do
     before(:all) do
-      @messages = []
+      @messages.clear
 
       Tackle.publish("2", @tackle_options) # will be processed
 
@@ -59,9 +62,9 @@ describe "Manual Ack Mode" do
 
   describe "nacked messages" do
     before(:all) do
-      @messages = []
+      @messages.clear
 
-      Tackle.publish("3", @tackle_options) # will be processed
+      Tackle.publish("3", @tackle_options) # will not be processed
 
       sleep 5
     end

--- a/spec/integration/manual_ack_spec.rb
+++ b/spec/integration/manual_ack_spec.rb
@@ -14,7 +14,7 @@ describe "Manual Ack Mode" do
       :manual_ack => true
     }
 
-    @acking_worker = Thread.new do
+    @worker = Thread.new do
       Tackle.consume(@tackle_options) do |message|
         # accept only positive numbers
         @messages << message
@@ -35,14 +35,14 @@ describe "Manual Ack Mode" do
   end
 
   describe "acked messages" do
-    before do
+    before(:all) do
       Tackle.publish("2", @tackle_options) # will be processed
 
       sleep 5
     end
 
     it "processes the message only once" do
-      expect(@messages).to eq([2])
+      expect(@messages).to eq(["2"])
     end
 
     it "cleares the queue" do

--- a/spec/integration/queue_creation_spec.rb
+++ b/spec/integration/queue_creation_spec.rb
@@ -4,6 +4,10 @@ describe "Queue creation" do
   before(:all) do
     @messages = []
 
+    BunnyHelper.delete_queue("test-service.test-key")
+    BunnyHelper.delete_queue("test-service.test-key.delay.1")
+    BunnyHelper.delete_queue("test-service.test-key.dead")
+
     @tackle_options = {
       :url => "amqp://localhost",
       :exchange => "test-exchange",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,17 @@ require "tackle"
 module BunnyHelper
   module_function
 
+  def delete_queue(queue_name)
+    conn = Bunny.new
+    conn.start
+    channel = conn.channel
+
+    queue = channel.queue(queue_name, {:durable => true})
+    queue.delete
+  ensure
+    conn.close
+  end
+
   def queue_exists?(queue_name)
     conn = Bunny.new
     conn.start

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ module BunnyHelper
 
     queue = channel.queue(queue_name, {:durable => true})
     queue.delete
+  rescue Bunny::PreconditionFailed
   ensure
     conn.close
   end


### PR DESCRIPTION
By default, Tackle assumes that a message was successfully processed if no
exceptions were raised in the consume block. This behaviour is well suited for
handling unknown exceptions.

Sometimes however, we want to send a message to the retry queue without raising
an exception (and polluting our exception tracker with false positives).

For this purpose, tackle can be configured to consume messages in a "manual ack"
fashion. Pass `:manual_ack => true` to the consumer to activate the manual_ack
mode.

```ruby
require "tackle"

options = {
  :url => "amqp://localhost",
  :exchange => "users",
  :routing_key => "signed-up",
  :service => "user-mailer"
  :manual_ack => true
}

Tackle.consume(options) do |message|
  puts message

  Tackle::ACK
end
```

When Tackle consumes messages in the manual_ack mode, the return value of the
consumer block must be either `Tackle::ACK` or `Tackle::NACK`. In case the
response is `Tackle::NACK` the message is put on the retry queue.

```ruby
require "tackle"

options = {
  :url => "amqp://localhost",
  :exchange => "numbers",
  :routing_key => "positive-numbers",
  :service => "number-processor",
  :manual_ack => true
}

Tackle.consume(options) do |message|
  # accept only positive numbers

  if message["value"].even?
    Tackle::ACK
  else
    Tackle::NACK
  end
end
```

If neither Tackle::ACK nor Tackle::NACK are returned, tackle assumes
that the response is negative.