### PR TITLE
Log timeout errors

### DIFF
--- a/lib/tackle/connection.rb
+++ b/lib/tackle/connection.rb
@@ -23,6 +23,10 @@ module Tackle
       @channel.on_uncaught_exception(&@exception_handler)
 
       @logger.info("Connected to channel")
+    rescue Timeout::Error => ex
+      @logger.error("Timeout while connecting to RabbitMQ server message='#{ex}'")
+
+      raise ex
     rescue StandardError => ex
       @logger.error("Error while connecting to RabbitMQ message='#{ex}'")
 

--- a/lib/tackle/publisher.rb
+++ b/lib/tackle/publisher.rb
@@ -19,7 +19,7 @@ module Tackle
       exchange.publish(message, :routing_key => @routing_key, :persistent => true)
       @logger.info("Publishing message finished exchange='#{@exchange_name}' routing_key='#{@routing_key}'")
     ensure
-      connection.close
+      connection.close unless connection.nil?
     end
 
   end

--- a/lib/tackle/version.rb
+++ b/lib/tackle/version.rb
@@ -1,3 +1,3 @@
 module Tackle
-  VERSION = "1.1.0".freeze
+  VERSION = "1.1.1".freeze
 end

--- a/spec/integration/publisher_spec.rb
+++ b/spec/integration/publisher_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe "Publishing messages to a queue" do
+
+  before do
+    @tackle_options = {
+      :url => "amqp://localhost",
+      :exchange => "test-exchange",
+      :routing_key => "test-key",
+      :service => "healthy-service",
+      :retry_delay => 1,
+      :retry_limit => 3
+    }
+  end
+
+  context "can't establish connection to server" do
+    before do
+      allow(Bunny).to receive(:new).and_raise(Timeout::Error)
+    end
+
+    it "consumes the message" do
+      expect { Tackle.publish("Hi!", @tackle_options) }.to raise_exception(Timeout::Error)
+    end
+  end
+
+end


### PR DESCRIPTION
Previously we received messages like

```
undefined method `close' for nil:NilClass Did you mean? clone
```

And it was not clear what was the issue.

This PR fixes the issue by raising a timeout error, and logging it.